### PR TITLE
Fixed chapter links and fixed/added other site links

### DIFF
--- a/ch02-keys-and-signatures.asciidoc
+++ b/ch02-keys-and-signatures.asciidoc
@@ -64,7 +64,7 @@ image:images/crazy-mr-bean.png[Crazy Mr Bean GIF]
 
 So what can we do with this now?
 
-Imagine I own 1 Bitcoin and I'd like to send it to my friend @SahilBloom.
+Imagine I own 1 Bitcoin and I'd like to send it to my friend link:https://twitter.com/SahilBloom[@SahilBloom].
 
 In order to send this coin, I need a way to "prove" to the network that I am the rightful owner of this coin and authorize it's transfer.
 

--- a/ch03-mining.asciidoc
+++ b/ch03-mining.asciidoc
@@ -10,7 +10,7 @@ Before we start, it’s important you have some understanding of what a Hash is.
 
 A Hash is like a data fingerprint that’s calculated using some fancy math.
 
-(If this is new, I suggest reading my link:ch01.asciidoc[previous beginner-friendly thread first]).
+(If this is new, I suggest reading my link:ch01-hash-functions.asciidoc[previous beginner-friendly thread first]).
 
 You can play around with Hashes using this helpful website (and I'll be using it for our demonstrations here):
 

--- a/ch04-difficulty-adjustment.asciidoc
+++ b/ch04-difficulty-adjustment.asciidoc
@@ -142,7 +142,7 @@ Faster or slower block times affect the rate of new bitcoins entering the market
 
 In every other asset class, when the price goes UP, more of it gets produced, and the supply begins to increase more quickly, which ultimately drives the price back DOWN.
 
-@saifedean has explained this wonderfully in his book link:https://www.amazon.com/Bitcoin-Standard-Decentralized-Alternative-Central/dp/1119473861[The Bitcoin Standard].
+link:https://twitter.com/saifedean[@saifedean] has explained this wonderfully in his book link:https://www.amazon.com/Bitcoin-Standard-Decentralized-Alternative-Central/dp/1119473861[The Bitcoin Standard].
 
 But bitcoin fixes this.
 

--- a/ch04-difficulty-adjustment.asciidoc
+++ b/ch04-difficulty-adjustment.asciidoc
@@ -18,7 +18,7 @@ If you said number two, you're right!
 Go ahead and try it yourself with this online hash calculator if you like.
 
 .SHA256 Hash Calculator
-image:images/xorbin.gif[SHA256 Hash Calculator, link:https://xorbin.com/tools/sha256-hash-calculator]
+image:images/xorbin.gif[SHA256 Hash Calculator, link=https://xorbin.com/tools/sha256-hash-calculator]
 
 Look, in just about 30 seconds of clicking, I found a hash that starts with a 0.
 

--- a/ch05-transaction-anatomy.asciidoc
+++ b/ch05-transaction-anatomy.asciidoc
@@ -21,7 +21,7 @@ This is used to uniquely identify a transaction, and it comes from taking the SH
 
 image:images/sample-transaction-circled.png[sample-transaction-circled]
 
-(Side note, for a primer on what a SHA-256 Hash is, check out link:ch01.asciidoc[my thread on Hash functions]).
+(Side note, for a primer on what a SHA-256 Hash is, check out link:ch01-hash-functions.asciidoc[my thread on Hash functions]).
 
 Next lets look at those two entries on the right. These are the Outputs (recipients) of the transaction.
 

--- a/ch05-transaction-anatomy.asciidoc
+++ b/ch05-transaction-anatomy.asciidoc
@@ -138,7 +138,7 @@ Make sense? Awesome!
 
 But here's a question for you.
 
-Say I only own a single UTXO, worth 0.69561192 BTC, but I want to send my friend @SahilBloom 0.2862 BTC?
+Say I only own a single UTXO, worth 0.69561192 BTC, but I want to send my friend link:https://twitter.com/SahilBloom[@SahilBloom] 0.2862 BTC?
 
 image:images/confused-dogs.png[Confused Dogs GIF]
 
@@ -152,7 +152,7 @@ image:images/change.png[Change GIF]
 
 Bitcoin uses a similar concept of Change.
 
-For me to pay @SahilBloom 0.2862 using my 0.69561192 UTXO, I'll create a transaction with two Outputs:
+For me to pay link:https://twitter.com/SahilBloom[@SahilBloom] 0.2862 using my 0.69561192 UTXO, I'll create a transaction with two Outputs:
 
 - One for 0.2862 to Sahil
 - And one that gives the remaining 0.40861192 change back to me.

--- a/ch06-addresses.asciidoc
+++ b/ch06-addresses.asciidoc
@@ -33,9 +33,9 @@ image:images/only-one-vacancy.png[Only One Vacancy GIF]
 
 These are called "Pay to Public Key Hash" ("P2PKH") addresses because most of the rest of that data in the Address is a Hash of Alice’s Public Key.
 
-For some background on what Public Keys and Signatures are, I'd suggest checking out my link:ch08.asciidoc[previous thread].
+For some background on what Public Keys and Signatures are, I'd suggest checking out my link:ch02-keys-and-signatures.asciidoc[previous thread].
 
-For background on what a Hash is, check out link:ch01.asciidoc[this one].
+For background on what a Hash is, check out link:ch01-hash-functions.asciidoc[this one].
 
 You might be wondering why the address has the Hash of Alice's Public Key, and not just the actual Public Key.
 

--- a/ch07-fees.asciidoc
+++ b/ch07-fees.asciidoc
@@ -97,7 +97,7 @@ image:images/check.png[Check GIF]
 
 So how can all this help you manage your own wallet?
 
-To demonstrate, imagine there are two faithful bitcoiners, Alice and Bob, each of whom buys $10 of bitcoin every day on @CashApp 😉.
+To demonstrate, imagine there are two faithful bitcoiners, Alice and Bob, each of whom buys $10 of bitcoin every day on link:https://twitter.com/CashApp[@CashApp] 😉.
 
 Like good bitcoiners, both of them withdraw all their funds to their own cold storage.
 
@@ -105,7 +105,7 @@ But their methods are slightly different.
 
 Alice withdraws her full balance once every 2 weeks, but Bob withdraws his full balance once every day!
 
-Now imagine 10 weeks later, they each want to deposit all their funds back into @CashApp - who's going to pay more in fees?
+Now imagine 10 weeks later, they each want to deposit all their funds back into link:https://twitter.com/CashApp[@CashApp] - who's going to pay more in fees?
 
 Well, lets examine at their wallets.
 

--- a/ch08-rbf-cpfp.asciidoc
+++ b/ch08-rbf-cpfp.asciidoc
@@ -20,7 +20,7 @@ But all those new transactions were unexpectedly added quickly, and they bid hig
 
 image:images/auction-wars.png[Auction Wars GIF]
 
-(For some background on why more volume of transactions causes higher fees, you can check out link:ch07.asciidoc[my thread on transaction fees]).
+(For some background on why more volume of transactions causes higher fees, you can check out link:ch07-fees.asciidoc[my thread on transaction fees]).
 
 Now your transaction has a low fee compared to all these new ones, so it is stuck behind them.
 
@@ -43,7 +43,7 @@ Your transaction likely had two Outputs:
 
 image:images/parent-transaction.png[Parent Transaction]
 
-(If you're not sure what an Output is, I suggest reading my thread on link:ch05.asciidoc[the Anatomy of a Transaction first]).
+(If you're not sure what an Output is, I suggest reading my thread on link:ch05-transaction-anatomy.asciidoc[the Anatomy of a Transaction first]).
 
 So your Parent transaction is stuck with a low fee... what to do?
 

--- a/ch09-consolidations.asciidoc
+++ b/ch09-consolidations.asciidoc
@@ -6,7 +6,7 @@ What are they? How do they work? 👇
 
 Before we start, this thread requires a little bit of background knowledge.
 
-If you're new, I recommend checking out the threads on link:ch03.asciidoc[Bitcoin Transactions] and link:ch04.asciidoc[Transaction Fees] if you haven't already.
+If you're new, I recommend checking out the threads on link:ch05-transaction-anatomy.asciidoc[Bitcoin Transactions] and link:ch07-fees.asciidoc[Transaction Fees] if you haven't already.
 
 To explain Consolidation Transactions, lets consider somebody named Alice, who runs an online store selling crystals.
 

--- a/ch10-censorship.asciidoc
+++ b/ch10-censorship.asciidoc
@@ -6,7 +6,7 @@ What are the technical differences between centralized platforms and decentraliz
 
 Let's dive in 👇
 
-Over the past few years we've seen a lot of controversial figures get banned from popular websites like @Twitter, @YouTube, @Facebook, and @Instagram.
+Over the past few years we've seen a lot of controversial figures get banned from popular websites like link:https://twitter.com/Twitter[@Twitter], link:https://twitter.com/YouTube[@YouTube], link:https://twitter.com/Facebook[@Facebook], and link:https://twitter.com/Instagram[@Instagram].
 
 image:images/ii-topic.png[ii topic GIF]
 


### PR DESCRIPTION
This PR updates the links in chapters that had issues and included missing Twitter links. Below is a breakdown of the changes:

- Fixed all links to chapters due to the chapter filename changes in #11.
- Fixed a broken link to the xorbin site in Chapter 4.
- Included all the missing Twitter links.

Let me know if you need the commits squashed first.